### PR TITLE
Add a prototype high-level python API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 *.#*
 .DS_Store
 
+# IDE crap
+.idea/
+
 # Compiled Object files
 *.slo
 *.lo

--- a/examples/pybgpstream-template.py
+++ b/examples/pybgpstream-template.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+#
+# This file is part of pybgpstream
+#
+# CAIDA, UC San Diego
+# bgpstream-info@caida.org
+#
+# Copyright (C) 2015 The Regents of the University of California.
+# Authors: Alistair King
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 2 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+This is a sample script that uses the high-level pybgpstream module.
+
+You can use this script as a starting point when creating new applications that use PyBGPStream
+"""
+
+import pybgpstream
+
+# create and configure the stream
+stream = pybgpstream.BGPStream(
+    from_time="2017-07-07 00:00:00", until_time="2017-07-07 00:10:00 UTC",
+    collectors=["route-views.sg", "route-views.eqix"],
+    record_type="updates",
+    filter="peer 11666 and prefix more 210.180.0.0/16"
+)
+
+# add any additional (or dynamic) filters
+# e.g. from peer AS 11666 regarding the more-specifics of 210.180.0.0/16:
+# stream.parse_filter_string("peer 11666 and prefix more 210.180.0.0/16")
+# or using the old filter interface:
+# stream.add_filter("peer-asn", "11666")
+# stream.add_filter("prefix-more", "210.180.0.0/16")
+
+# read elems
+for rec, elem in stream:
+    # do something with rec and elem
+    print "Received %s at time %d from collector %s" % (elem.type, rec.time, rec.collector)
+    if elem.type in ["A", "W"]:
+        print "  Peer ASN: %s, Pfx: %s" % (elem.peer_asn, elem.fields["prefix"])
+
+# alternatively, records and elems can be read in nested loops:
+for rec in stream.records():
+    # do something with rec (e.g., choose to continue based on timestamp)
+    print "Received %s record at time %d from collector %s" % (rec.type, rec.time, rec.collector)
+    for elem in rec:
+        # do something with rec and/or elem
+        print "  Elem Type: %s" % elem.type

--- a/pybgpstream/__init__.py
+++ b/pybgpstream/__init__.py
@@ -1,0 +1,1 @@
+from pybgpstream import *

--- a/pybgpstream/pybgpstream.py
+++ b/pybgpstream/pybgpstream.py
@@ -1,0 +1,123 @@
+# This file is part of pybgpstream
+#
+# CAIDA, UC San Diego
+# bgpstream-info@caida.org
+#
+# Copyright (C) 2015 The Regents of the University of California.
+# Authors: Alistair King
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 2 of the License, or (at your option) any later
+# version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime
+import dateutil.parser
+import _pybgpstream
+
+
+class BGPStream:
+
+    def __init__(self,
+                 from_time=None,
+                 until_time=None,
+                 project=None,
+                 projects=None,
+                 collector=None,
+                 collectors=None,
+                 record_type=None,
+                 record_types=None,
+                 filter=None,
+                 ):
+        # create a low-level bgpstream instance
+        self.stream = _pybgpstream.BGPStream()
+
+        # pass along any config options the user asked for
+
+        # time interval (accepts string date/times)
+        from_epoch = self._datestr_to_epoch(from_time)
+        until_epoch = self._datestr_to_epoch(until_time)
+        if from_epoch or until_epoch:
+            print "%s,%s" % (from_epoch, until_epoch)
+            self.stream.add_interval_filter(from_epoch, until_epoch)
+
+        self._maybe_add_filter("project", project, projects)
+        self._maybe_add_filter("collector", collector, collectors)
+        self._maybe_add_filter("record-type", record_type, record_types)
+
+        if filter is not None:
+            self.stream.parse_filter_string(filter)
+
+        self.stream.start()
+
+    def __iter__(self):
+        for _rec in self.records():
+            for _elem in _rec:
+                yield (_rec, _elem)
+
+    def __getattr__(self, attr):
+        try:
+            return getattr(self.stream, attr)
+        except AttributeError:
+            return object.__getattr__(self, attr)
+
+    def records(self):
+        while True:
+            _rec = self.stream.get_next_record()
+            if _rec is None:
+                return
+            yield BGPRecord(_rec)
+
+    def _maybe_add_filter(self, fname, f_single, f_list):
+        if f_list is None:
+            f_list = []
+        if f_single is not None:
+            f_list.append(f_single)
+        for f in f_list:
+            self.stream.add_filter(fname, f)
+
+    @staticmethod
+    def _datestr_to_epoch(datestr):
+        if datestr is None:
+            return 0
+        dt = dateutil.parser.parse(datestr, ignoretz=True)
+        return int((dt - datetime.datetime(1970, 1, 1)).total_seconds())
+
+
+class BGPRecord:
+
+    def __init__(self, rec):
+        self.rec = rec
+
+    def __iter__(self):
+        while True:
+            _elem = self.rec.get_next_elem()
+            if _elem is None:
+                return
+            yield BGPElem(_elem)
+
+    def __getattr__(self, attr):
+        try:
+            return getattr(self.rec, attr)
+        except AttributeError:
+            return object.__getattr__(self, attr)
+
+
+class BGPElem:
+
+    def __init__(self, elem):
+        self.elem = elem
+
+    def __getattr__(self, attr):
+        try:
+            return getattr(self.elem, attr)
+        except AttributeError:
+            return object.__getattr__(self, attr)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, Extension
+from setuptools import setup, Extension, find_packages
 
 _pybgpstream_module = Extension("_pybgpstream",
                                 libraries = ["bgpstream"],
@@ -26,4 +26,6 @@ setup(name = "pybgpstream",
           'Operating System :: POSIX',
           ],
       keywords='_pybgpstream pybgpstream bgpstream bgp mrt routeviews route-views ris routing',
-      ext_modules = [_pybgpstream_module,])
+      packages=find_packages(),
+      install_requires=['python-dateutil'],
+      ext_modules=[_pybgpstream_module, ])


### PR DESCRIPTION
This is a thin wrapper around `_pybgpstream` and should make it much more enjoyable to use BGPStream from within Python. See examples/pybgpstream-template.py for an example of how to use this API.