### PR TITLE
check py3 compatibility

### DIFF
--- a/examples/pybgpstream-template.py
+++ b/examples/pybgpstream-template.py
@@ -53,12 +53,12 @@ for elem in stream:
     # e.g. elem.time
     # or via elem.record
     # e.g. elem.record.time
-    print elem
+    print(elem)
 
 # alternatively, records and elems can be read in nested loops:
 for rec in stream.records():
     # do something with rec (e.g., choose to continue based on timestamp)
-    print "Received %s record at time %d from collector %s" % (rec.type, rec.time, rec.collector)
+    print("Received %s record at time %d from collector %s" % (rec.type, rec.time, rec.collector))
     for elem in rec:
         # do something with rec and/or elem
-        print "  Elem Type: %s" % elem.type
+        print("  Elem Type: %s" % elem.type)

--- a/examples/spark-recordcount.py
+++ b/examples/spark-recordcount.py
@@ -37,7 +37,10 @@ import math
 from pyspark import SparkConf, SparkContext
 from _pybgpstream import BGPStream, BGPRecord
 import sys
-import urllib.request, urllib.error, urllib.parse
+try:
+    import urllib.request as urllib_request
+except:
+    import urllib2 as urllib_request
 
 # Output one data point per day
 RESULT_GRANULARITY = 3600*24
@@ -56,7 +59,7 @@ PROJECTS = ('routeviews', 'ris')
 
 # Query the BGPStream broker and identify the collectors that are available
 def get_collectors():
-    response = urllib.request.urlopen(COLLECTORS_URL)
+    response = urllib_request.urlopen(COLLECTORS_URL)
     data = json.load(response)
     results = []
     for coll in data['data']['collectors']:

--- a/examples/spark-recordcount.py
+++ b/examples/spark-recordcount.py
@@ -37,7 +37,7 @@ import math
 from pyspark import SparkConf, SparkContext
 from _pybgpstream import BGPStream, BGPRecord
 import sys
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 
 # Output one data point per day
 RESULT_GRANULARITY = 3600*24
@@ -56,7 +56,7 @@ PROJECTS = ('routeviews', 'ris')
 
 # Query the BGPStream broker and identify the collectors that are available
 def get_collectors():
-    response = urllib2.urlopen(COLLECTORS_URL)
+    response = urllib.request.urlopen(COLLECTORS_URL)
     data = json.load(response)
     results = []
     for coll in data['data']['collectors']:

--- a/examples/topology.py
+++ b/examples/topology.py
@@ -62,5 +62,5 @@ while(stream.get_next_record(rec)):
          elem = rec.get_next_elem()
 
 # Output results
-print "Processed", rib_entries, "rib entries"
-print "Found", len(as_topology), "AS adjacencies"
+print("Processed", rib_entries, "rib entries")
+print("Found", len(as_topology), "AS adjacencies")

--- a/examples/tutorial_print.py
+++ b/examples/tutorial_print.py
@@ -48,11 +48,11 @@ stream.start()
 # print the stream
 rec = stream.get_next_record()
 while(rec):
-    print rec.status, rec.project +"."+ rec.collector, rec.time
+    print(rec.status, rec.project +"."+ rec.collector, rec.time)
     elem = rec.get_next_elem()
     while(elem):
-        print "\t", elem.type, elem.peer_address, elem.peer_asn, \
-            elem.type, elem.fields
+        print("\t", elem.type, elem.peer_address, elem.peer_asn, \
+            elem.type, elem.fields)
         elem = rec.get_next_elem()
     rec = stream.get_next_record()
 


### PR DESCRIPTION
current pybgpstream is already python3 compatible. only examples are python2 only. updated the examples using `2to3` tool to make them python3 compatible.

With libbgpstream installed, the following command can produce records:
```bash
python3 setup.py install
python3 examples/pybgpstream-template.py
```